### PR TITLE
Anpassung Bedeutung "sequence" als Eigenschaftswert für Attribute

### DIFF
--- a/16_UML_ModellierungII.md
+++ b/16_UML_ModellierungII.md
@@ -839,10 +839,10 @@ definierbar:
 | Eigenschaft | Bedeutung                                                                     |
 | ----------- | ----------------------------------------------------------------------------- |
 | `readOnly`  | unveränderlicher Wert                                                         |
-| `subsets`   | definiert die zugelassen Belegung als Untermenge eines anderen Attributs      |
+| `subsets`   | definiert die zugelassene Belegung als Untermenge eines anderen Attributs     |
 | `redefines` | überschreiben eines ererbten Attributes                                       |
-| `ordered`   | Inhaltes eines Attributes treten in geordneter Reihenfolge ohne Dublikate auf |
-| `bag`       | Attribute dürfen ungeordnet und mit Dublikaten versehen enthalten sein        |
+| `ordered`   | Inhalte eines Attributes treten in geordneter Reihenfolge ohne Duplikate auf  |
+| `bag`       | Attribute dürfen ungeordnet und mit Duplikaten versehen enthalten sein        |
 | `sequence`  | legt fest, dass der Inhalt sortiert ist, Duplikate sind erlaubt               |
 | `composite` | starke Abhängigkeitsbeziehungen                                               |
 


### PR DESCRIPTION
Meiner Recherche nach (vgl. Tabelle 7.1. "Collection types for MultiplicityElements" in der [OMG UML Spezifikation](https://www.omg.org/spec/UML/2.5.1/PDF)) weißt "sequence" zwar auf die Sortierung hin, Duplikate scheinen aber erlaubt zu sein.

https://github.com/TUBAF-IfI-LiaScript/VL_Softwareentwicklung/blob/60cca5ac0dcd8f32813338615c4676fd8a0a6e57/16_UML_ModellierungII.md?plain=1#L846


(außerdem noch kleine Rechtschreibkorrekturen vorgenommen)