### PR TITLE
Anpassung Methodenname an Funktionalität

### DIFF
--- a/19_Testen.md
+++ b/19_Testen.md
@@ -719,7 +719,7 @@ public class Test_DivideTwoValues
     }
 
     [Fact]
-    public void Check_StateZeroAsDivended()
+    public void Check_StateZeroAsDivisor()
     {
         // Arrange
         double result = 0;


### PR DESCRIPTION
Vorschlag: Methodenname anpassen, denn:
Divisor wir in diesem Test als 0 erwartet, nicht der Dividend