### PR TITLE
Korrekturvorschlag Tabelle Vergleich const, readonly, static readonly VL 08_OOPGrundlagenII

### DIFF
--- a/08_OOPGrundlagenII.md
+++ b/08_OOPGrundlagenII.md
@@ -605,7 +605,7 @@ Varianten "konstanter" Variablen in C#
 | Attribute           | `const`      | `readonly`            | `readonly static`     |
 | Veränderbar bis ... | Kompilierung | Ende des Konstruktors | Ende des Konstruktors |
 | Statisch            | Standard, ja | Nein                  | Ja                    |
-| Zugriff             | Klasse       | Instanz               | Instanz               |
+| Zugriff             | Klasse       | Instanz               | Klasse                |
 
 <!-- --{{0}}-- Idee des Codefragments:
   * Versuchen Sie die Variable innnerhalb von Main zu manipulieren


### PR DESCRIPTION
Korrekturvorschlag für diese Stelle: 
https://github.com/TUBAF-IfI-LiaScript/VL_Softwareentwicklung/blob/57c9a3cccba4a3550069cfddaaee5ea45b783c84/08_OOPGrundlagenII.md?plain=1#L603-L608

Durch die "static" Eigenschaft hätte ich erwartet, dass der Zugriff im "static readonly"-Fall über die Klasse erfolgt, nicht die Instanz.